### PR TITLE
fix/queryMiddleware-catch-only-postprocessing

### DIFF
--- a/src/middlewares/queryMiddleware.js
+++ b/src/middlewares/queryMiddleware.js
@@ -45,7 +45,7 @@ export default function({
           if (error) {
             return callback(...arguments);
           }
-          let processResponseError;
+          let processResponseError = null;
           let processedResponse;
           try {
             processedResponse = results.map((result, i) => {

--- a/src/middlewares/queryMiddleware.js
+++ b/src/middlewares/queryMiddleware.js
@@ -45,17 +45,20 @@ export default function({
           if (error) {
             return callback(...arguments);
           }
+          let processResponseError;
+          let processedResponse;
           try {
-            callback(error, results.map((result, i) => {
+            processedResponse = results.map((result, i) => {
               return queries[i].processResponse(result, {
                 transformTermKeys,
                 injectMetadata,
                 normalizeBoolean,
               });
-            }));
+            });
           } catch (e) {
-            callback(e);
+            processResponseError = e;
           }
+          callback(processResponseError, processedResponse);
         },
         options
       );


### PR DESCRIPTION
@Uhsac Is there a better way to write it?